### PR TITLE
[fixed issue #52] Direct to MainActivity after authentication & Firebase user login

### DIFF
--- a/kute-android-app/app/src/main/AndroidManifest.xml
+++ b/kute-android-app/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"></uses-permission>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
         android:name=".KuteApplication"
@@ -18,39 +18,38 @@
             android:value="@string/facebook_app_id" />
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="@string/googlemapApi"/>
+            android:value="@string/googlemapApi" />
 
-        <activity android:name=".SplashActivity">
+        <activity android:name=".SplashActivity"></activity>
+        <activity
+            android:name=".Activity.RegisterActivity"
+            android:windowSoftInputMode="stateHidden">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
-        <activity android:name=".Activity.RegisterActivity"
-            android:windowSoftInputMode="stateHidden">
-
-        </activity>
-
         <activity
             android:name="com.facebook.FacebookActivity"
             android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
             android:label="@string/app_name"
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
-        <activity android:name=".Activity.MainActivity">
-
-        </activity>
+        <activity android:name=".Activity.MainActivity"></activity>
         <activity
             android:name=".LandActivity"
             android:label="@string/title_activity_land"
             android:theme="@style/AppTheme">
 
         </activity>
-        <activity android:name=".Activity.TaskSelection"></activity>
-        <activity android:name=".Activity.VehicleSelection" ></activity>
-        <service android:name=".Services.BacKService"
-            android:process=":backservice"></service>
+        <activity android:name=".Activity.TaskSelection" />
+        <activity android:name=".Activity.VehicleSelection" />
+
+        <service
+            android:name=".Services.BacKService"
+            android:process=":backservice" />
+
+        <activity android:name=".Activity.NewUserActivity"></activity>
     </application>
 
 </manifest>

--- a/kute-android-app/app/src/main/java/com/scorelab/kute/kute/Activity/NewUserActivity.java
+++ b/kute-android-app/app/src/main/java/com/scorelab/kute/kute/Activity/NewUserActivity.java
@@ -1,0 +1,94 @@
+package com.scorelab.kute.kute.Activity;
+
+import android.app.ProgressDialog;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.Toast;
+
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.AuthResult;
+import com.google.firebase.auth.FirebaseAuth;
+import com.scorelab.kute.kute.R;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+//This class is to
+public class NewUserActivity extends AppCompatActivity {
+
+    public static final Pattern VALID_EMAIL_ADDRESS_REGEX = Pattern.compile("^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,6}$", Pattern.CASE_INSENSITIVE);
+    public ProgressDialog mDialog;
+
+    EditText email;
+    EditText password;
+    Button register;
+
+    private FirebaseAuth mAuth;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_new_user);
+
+        mAuth = FirebaseAuth.getInstance();
+        mDialog = new ProgressDialog(this);
+        mDialog.setMessage("Processing...");
+        mDialog.setCancelable(false);
+
+        email = (EditText) findViewById(R.id.reg_email);
+        password = (EditText) findViewById(R.id.reg_password);
+        register = (Button) findViewById(R.id.button_register);
+
+        register.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                mDialog.show();
+                registerNew();
+            }
+        });
+    }
+
+    private void registerNew(){
+        String s_email = email.getText().toString().trim();
+        String s_password = password.getText().toString();
+
+        if ((s_email.trim().length() != 0) && (s_password.length() >= 6)) {
+
+            if(validateEmail(s_email)){
+                mAuth.createUserWithEmailAndPassword(s_email, s_password).addOnCompleteListener(this, new OnCompleteListener<AuthResult>() {
+                    @Override
+                    public void onComplete(@NonNull Task<AuthResult> task) {
+                        if (task.isSuccessful()) {
+                            Toast.makeText(getApplicationContext(), "User Added", Toast.LENGTH_SHORT).show();
+                            email.setText("");
+                            password.setText("");
+                        } else {
+                            Log.d("REG ERROR",task.getResult().toString());
+                            Toast.makeText(getApplicationContext(), "Error in Teacher Registration", Toast.LENGTH_SHORT).show();
+                        }
+                        mDialog.hide();
+                    }
+                });
+            }else {
+                Toast.makeText(getApplicationContext(), "Invalid Email Address", Toast.LENGTH_SHORT).show();
+                mDialog.hide();
+            }
+
+        }else {
+            Toast.makeText(getApplicationContext(), "Incorrect Email / Password", Toast.LENGTH_SHORT).show();
+            mDialog.hide();
+        }
+    }
+
+    //To validate email address
+    public boolean validateEmail(String passedEmail){
+        Matcher matcher = VALID_EMAIL_ADDRESS_REGEX .matcher(passedEmail);
+        return matcher.find();
+    }
+}

--- a/kute-android-app/app/src/main/java/com/scorelab/kute/kute/Activity/RegisterActivity.java
+++ b/kute-android-app/app/src/main/java/com/scorelab/kute/kute/Activity/RegisterActivity.java
@@ -10,6 +10,7 @@ import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
+import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.Toast;
 
@@ -52,6 +53,8 @@ public class RegisterActivity extends AppCompatActivity implements
     private static final int RC_SIGN_IN = 9001;
 
     private SignInButton mSignInButton;
+    Button firebaseRegister;
+
 
     private GoogleApiClient mGoogleApiClient;
 
@@ -73,6 +76,11 @@ public class RegisterActivity extends AppCompatActivity implements
         switch (v.getId()) {
             case R.id.login_with_google:
                 signIn();
+                break;
+            //Added to register users with Firebase
+            case R.id.custom_signup_button:
+                Intent intent = new Intent(getBaseContext(), NewUserActivity.class);
+                startActivity(intent);
                 break;
         }
     }
@@ -151,9 +159,11 @@ public class RegisterActivity extends AppCompatActivity implements
 
             // Assign fields
             mSignInButton = (SignInButton) findViewById(R.id.login_with_google);
+            firebaseRegister = (Button) findViewById(R.id.custom_signup_button);
 
             // Set click listeners
             mSignInButton.setOnClickListener(this);
+            firebaseRegister.setOnClickListener(this);
 
             // Configure Google Sign In
             GoogleSignInOptions gso = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
@@ -180,7 +190,7 @@ public class RegisterActivity extends AppCompatActivity implements
                         // User is signed in
                         Log.d(TAG, "onAuthStateChanged:signed_in:" + user.getUid());
                         Toast.makeText(getApplicationContext(), "Facebook  User " + user.getPhotoUrl(), Toast.LENGTH_LONG).show();
-                        getImage(user.getPhotoUrl().toString());
+                        //getImage(user.getPhotoUrl().toString());
 
 
                         Intent intentdone=new Intent(RegisterActivity.this, SplashActivity.class);

--- a/kute-android-app/app/src/main/java/com/scorelab/kute/kute/Activity/RegisterActivity.java
+++ b/kute-android-app/app/src/main/java/com/scorelab/kute/kute/Activity/RegisterActivity.java
@@ -1,6 +1,7 @@
 package com.scorelab.kute.kute.Activity;
 
 
+import android.app.ProgressDialog;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.os.AsyncTask;
@@ -11,6 +12,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.Toast;
 
@@ -46,14 +48,20 @@ import com.scorelab.kute.kute.Util.ImageHandler;
 
 public class RegisterActivity extends AppCompatActivity implements
         GoogleApiClient.OnConnectionFailedListener,
-        View.OnClickListener{
+        View.OnClickListener {
 
     RequestQueue rq;
     private static final String TAG = "SignInActivity";
     private static final int RC_SIGN_IN = 9001;
 
     private SignInButton mSignInButton;
+
     Button firebaseRegister;
+    Button firebaseLogin;
+    EditText userEmail;
+    EditText userPassword;
+
+    public ProgressDialog mDialog;
 
 
     private GoogleApiClient mGoogleApiClient;
@@ -82,12 +90,18 @@ public class RegisterActivity extends AppCompatActivity implements
                 Intent intent = new Intent(getBaseContext(), NewUserActivity.class);
                 startActivity(intent);
                 break;
+            case R.id.custom_signin_button:
+                String email = userEmail.getText().toString();
+                String password = userPassword.getText().toString();
+                mDialog.show();
+                authWIthEmailPassword(email,password);
+                break;
         }
     }
 
     @Override
     public void onConnectionFailed(@NonNull ConnectionResult connectionResult) {
-// An unresolvable error has occurred and Google APIs (including Sign-In) will not
+        // An unresolvable error has occurred and Google APIs (including Sign-In) will not
         // be available.
         Log.d(TAG, "onConnectionFailed:" + connectionResult);
         Toast.makeText(this, "Google Play Services error.", Toast.LENGTH_SHORT).show();
@@ -114,8 +128,7 @@ public class RegisterActivity extends AppCompatActivity implements
                 // Google Sign In failed
                 Log.e(TAG, "Google Sign In failed.");
             }
-        }
-        else{
+        } else {
             mCallbackManager.onActivityResult(requestCode, resultCode, data);
         }
     }
@@ -137,11 +150,11 @@ public class RegisterActivity extends AppCompatActivity implements
                             Toast.makeText(RegisterActivity.this, "Authentication failed.",
                                     Toast.LENGTH_SHORT).show();
                         } else {
-                            Toast.makeText(RegisterActivity.this, "Authentication Done."+task.getResult().getUser().getDisplayName()+" - "+task.getResult().getUser().getDisplayName()+" - "+task.getResult().getUser().getEmail()+" - "+task.getResult().getUser().getPhotoUrl().getPath()+" - ",
+                            Toast.makeText(RegisterActivity.this, "Authentication Done." + task.getResult().getUser().getDisplayName() + " - " + task.getResult().getUser().getDisplayName() + " - " + task.getResult().getUser().getEmail() + " - " + task.getResult().getUser().getPhotoUrl().getPath() + " - ",
                                     Toast.LENGTH_SHORT).show();
                             getImage(task.getResult().getUser().getPhotoUrl().toString());
 
-                            Intent intentdone=new Intent(RegisterActivity.this, SplashActivity.class);
+                            Intent intentdone = new Intent(RegisterActivity.this, MainActivity.class);
                             startActivity(intentdone);
 
                         }
@@ -160,10 +173,19 @@ public class RegisterActivity extends AppCompatActivity implements
             // Assign fields
             mSignInButton = (SignInButton) findViewById(R.id.login_with_google);
             firebaseRegister = (Button) findViewById(R.id.custom_signup_button);
+            firebaseLogin = (Button) findViewById(R.id.custom_signin_button);
+
+            userEmail = (EditText) findViewById(R.id.login_email);
+            userPassword = (EditText) findViewById(R.id.login_password);
+
+            mDialog = new ProgressDialog(this);
+            mDialog.setMessage("Processing...");
+            mDialog.setCancelable(false);
 
             // Set click listeners
             mSignInButton.setOnClickListener(this);
             firebaseRegister.setOnClickListener(this);
+            firebaseLogin.setOnClickListener(this);
 
             // Configure Google Sign In
             GoogleSignInOptions gso = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
@@ -177,8 +199,6 @@ public class RegisterActivity extends AppCompatActivity implements
 
             // Initialize FirebaseAuth
             mFirebaseAuth = FirebaseAuth.getInstance();
-
-
             //Facebook
             mAuth = FirebaseAuth.getInstance();
             // [START auth_state_listener]
@@ -189,18 +209,17 @@ public class RegisterActivity extends AppCompatActivity implements
                     if (user != null) {
                         // User is signed in
                         Log.d(TAG, "onAuthStateChanged:signed_in:" + user.getUid());
-                        Toast.makeText(getApplicationContext(), "Facebook  User " + user.getPhotoUrl(), Toast.LENGTH_LONG).show();
+                        Toast.makeText(getApplicationContext(), "Logged In", Toast.LENGTH_SHORT).show();
                         //getImage(user.getPhotoUrl().toString());
 
-
-                        Intent intentdone=new Intent(RegisterActivity.this, SplashActivity.class);
+                        Intent intentdone = new Intent(RegisterActivity.this, MainActivity.class);
                         startActivity(intentdone);
 
 
                     } else {
                         // User is signed out
                         Log.d(TAG, "onAuthStateChanged:signed_out");
-                        Toast.makeText(getApplicationContext(), "Facebook  User signed out", Toast.LENGTH_LONG).show();
+                        Toast.makeText(getApplicationContext(), "Please Login", Toast.LENGTH_SHORT).show();
                     }
                     // [START_EXCLUDE]
 
@@ -221,8 +240,7 @@ public class RegisterActivity extends AppCompatActivity implements
                         Log.d(TAG, "facebook:onSuccess:" + loginResult);
 
                         handleFacebookAccessToken(loginResult.getAccessToken());
-                    }
-                    catch (Exception e){
+                    } catch (Exception e) {
                         e.printStackTrace();
 
                     }
@@ -230,14 +248,13 @@ public class RegisterActivity extends AppCompatActivity implements
 
                 @Override
                 public void onCancel() {
-                    try{
-                    Log.d(TAG, "facebook:onCancel");
-                    // [START_EXCLUDE]
-                    Toast.makeText(getApplicationContext(), "Facebook  Cancel", Toast.LENGTH_LONG).show();
-                    //updateUI(null);
-                    // [END_EXCLUDE]
-                    }
-                    catch (Exception e){
+                    try {
+                        Log.d(TAG, "facebook:onCancel");
+                        // [START_EXCLUDE]
+                        Toast.makeText(getApplicationContext(), "Facebook  Cancel", Toast.LENGTH_LONG).show();
+                        //updateUI(null);
+                        // [END_EXCLUDE]
+                    } catch (Exception e) {
                         e.printStackTrace();
 
                     }
@@ -245,28 +262,26 @@ public class RegisterActivity extends AppCompatActivity implements
 
                 @Override
                 public void onError(FacebookException error) {
-                    try{
+                    try {
 
-                    Log.d(TAG, "facebook:onError", error);
-                    // [START_EXCLUDE]
-                    Toast.makeText(getApplicationContext(), "Facebook  Error "+error.getMessage(), Toast.LENGTH_LONG).show();
-                    //updateUI(null);
-                    // [END_EXCLUDE]
-                    }
-                    catch (Exception e){
+                        Log.d(TAG, "facebook:onError", error);
+                        // [START_EXCLUDE]
+                        Toast.makeText(getApplicationContext(), "Facebook  Error " + error.getMessage(), Toast.LENGTH_LONG).show();
+                        //updateUI(null);
+                        // [END_EXCLUDE]
+                    } catch (Exception e) {
                         e.printStackTrace();
 
                     }
                 }
             });
 
-        }
-        catch (Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
-            Toast.makeText(getApplicationContext(),e.getMessage(),Toast.LENGTH_LONG).show();
+            Toast.makeText(getApplicationContext(), e.getMessage(), Toast.LENGTH_LONG).show();
         }
 
-        rq= Volley.newRequestQueue(this);
+        rq = Volley.newRequestQueue(this);
     }
 
     @Override
@@ -288,7 +303,7 @@ public class RegisterActivity extends AppCompatActivity implements
     private void handleFacebookAccessToken(AccessToken token) {
         Log.d(TAG, "handleFacebookAccessToken:" + token);
         // [START_EXCLUDE silent]
-        Toast.makeText(getApplicationContext(),"Facebook  show dialog",Toast.LENGTH_LONG).show();
+        Toast.makeText(getApplicationContext(), "Facebook  show dialog", Toast.LENGTH_LONG).show();
         //showProgressDialog();
         // [END_EXCLUDE]
 
@@ -297,24 +312,23 @@ public class RegisterActivity extends AppCompatActivity implements
                 .addOnCompleteListener(this, new OnCompleteListener<AuthResult>() {
                     @Override
                     public void onComplete(@NonNull Task<AuthResult> task) {
-                        try{
-                        Log.d(TAG, "signInWithCredential:onComplete:" + task.isSuccessful());
+                        try {
+                            Log.d(TAG, "signInWithCredential:onComplete:" + task.isSuccessful());
 
-                        // If sign in fails, display a message to the user. If sign in succeeds
-                        // the auth state listener will be notified and logic to handle the
-                        // signed in user can be handled in the listener.
-                        if (!task.isSuccessful()) {
-                            Log.w(TAG, "signInWithCredential", task.getException());
-                            Toast.makeText(RegisterActivity.this, "Authentication failed.",
-                                    Toast.LENGTH_SHORT).show();
-                        }
+                            // If sign in fails, display a message to the user. If sign in succeeds
+                            // the auth state listener will be notified and logic to handle the
+                            // signed in user can be handled in the listener.
+                            if (!task.isSuccessful()) {
+                                Log.w(TAG, "signInWithCredential", task.getException());
+                                Toast.makeText(RegisterActivity.this, "Authentication failed.",
+                                        Toast.LENGTH_SHORT).show();
+                            }
 
-                        // [START_EXCLUDE]
-                        Toast.makeText(getApplicationContext(),"Facebook  hide dialog",Toast.LENGTH_LONG).show();
-                        //hideProgressDialog();
-                        // [END_EXCLUDE]
-                        }
-                        catch (Exception e){
+                            // [START_EXCLUDE]
+                            Toast.makeText(getApplicationContext(), "Facebook  hide dialog", Toast.LENGTH_LONG).show();
+                            //hideProgressDialog();
+                            // [END_EXCLUDE]
+                        } catch (Exception e) {
                             e.printStackTrace();
 
                         }
@@ -328,20 +342,33 @@ public class RegisterActivity extends AppCompatActivity implements
     public void signOut() {
         mAuth.signOut();
         LoginManager.getInstance().logOut();
-        Toast.makeText(getApplicationContext(),"You have been Signout from the Kute",Toast.LENGTH_LONG).show();
+        Toast.makeText(getApplicationContext(), "You have been Signout from the Kute", Toast.LENGTH_LONG).show();
         //updateUI(null);
     }
-public void getImage(String url){
-    ImageRequest ir = new ImageRequest(url, new Response.Listener<Bitmap>() {
-        @Override
-        public void onResponse(Bitmap response) {
-            ImageHandler.saveImageToprefrence(getSharedPreferences(ImageHandler.MainKey,MODE_PRIVATE),response);
-            ImageView iv=(ImageView)findViewById(R.id.imageView);
-            iv.setImageBitmap(response);
-        }
-    }, 0, 0, null, null);
-    rq.add(ir);
 
-}
+    public void getImage(String url) {
+        ImageRequest ir = new ImageRequest(url, new Response.Listener<Bitmap>() {
+            @Override
+            public void onResponse(Bitmap response) {
+                ImageHandler.saveImageToprefrence(getSharedPreferences(ImageHandler.MainKey, MODE_PRIVATE), response);
+                ImageView iv = (ImageView) findViewById(R.id.imageView);
+                iv.setImageBitmap(response);
+            }
+        }, 0, 0, null, null);
+        rq.add(ir);
+
+    }
+
+    private void authWIthEmailPassword(String email, String password) {
+        mAuth.signInWithEmailAndPassword(email, password).addOnCompleteListener(this, new OnCompleteListener<AuthResult>() {
+            @Override
+            public void onComplete(@NonNull Task<AuthResult> task) {
+                if (!task.isSuccessful()) {
+                    Toast.makeText(getApplicationContext(), "Login Failed", Toast.LENGTH_SHORT).show();
+                }
+                mDialog.hide();
+            }
+        });
+    }
 
 }

--- a/kute-android-app/app/src/main/java/com/scorelab/kute/kute/LandActivity.java
+++ b/kute-android-app/app/src/main/java/com/scorelab/kute/kute/LandActivity.java
@@ -235,6 +235,8 @@ public class LandActivity extends AppCompatActivity
             return;
         }
         mGoogleMap.setMyLocationEnabled(true);
+        mGoogleMap.getUiSettings().setZoomControlsEnabled(true);
+        mGoogleMap.getUiSettings().setZoomGesturesEnabled(true);
     }
 
 

--- a/kute-android-app/app/src/main/res/layout/activity_new_user.xml
+++ b/kute-android-app/app/src/main/res/layout/activity_new_user.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+xmlns:tools="http://schemas.android.com/tools"
+android:id="@+id/activity_register"
+android:layout_width="match_parent"
+android:layout_height="match_parent"
+android:paddingBottom="@dimen/activity_vertical_margin"
+android:paddingLeft="@dimen/activity_horizontal_margin"
+android:paddingRight="@dimen/activity_horizontal_margin"
+android:paddingTop="@dimen/activity_vertical_margin"
+android:orientation="vertical"
+tools:context="com.scorelab.kute.kute.Activity.NewUserActivity">
+
+<TextView
+    android:text="Register New User"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="10dp" />
+
+<EditText
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:inputType="textEmailAddress"
+    android:ems="10"
+    android:id="@+id/reg_email"
+    android:hint="Email"/>
+
+<EditText
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:inputType="textPassword"
+    android:ems="10"
+    android:id="@+id/reg_password"
+    android:hint="Password"/>
+
+<Button
+    android:id="@+id/button_register"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="20dp"
+    android:background="@color/colorPrimary"
+    android:fontFamily="sans-serif-light"
+    android:text="Register"
+    android:textColor="#FFFFFF" />
+
+<TextView
+    android:text="** Minimum Password Length Should Be 6 Characters"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="10dp" />
+</LinearLayout>

--- a/kute-android-app/app/src/main/res/layout/signin.xml
+++ b/kute-android-app/app/src/main/res/layout/signin.xml
@@ -61,7 +61,8 @@
                 android:layout_marginBottom="16dp"
                 android:hint="Email"
                 android:tag="email_edittext"
-                android:inputType="textEmailAddress" />
+                android:inputType="textEmailAddress"
+                android:id="@+id/login_email"/>
 
             <EditText
                 android:layout_width="match_parent"
@@ -69,7 +70,8 @@
                 android:layout_marginBottom="16dp"
                 android:hint="Password"
                 android:tag="password_edittext"
-                android:inputType="textPassword" />
+                android:inputType="textPassword"
+                android:id="@+id/login_password"/>
 
             <LinearLayout
                 android:layout_width="match_parent"


### PR DESCRIPTION
Issue #52 
In previous code it was direct to the splash screen again and again after login, due to below code line. This was happened in both Google, Facebook and Firebase authentication 
```
Intent intentdone = new Intent(RegisterActivity.this, SplashActivity.class);
startActivity(intentdone);
```

I have corrected it to direct to ```MainActivity.java``` after correct user authentication. 

Also I have developed user login functionality with Firebase users. For that I have added a method named 
```private void authWIthEmailPassword(String email, String password)``` to the ```RegisterActivity.java```

Other than that I have done several simple corrections and enhancements

- Added ProgressDialog while user sign in. This dialog show when user click sign in button and disappear the process completion (network requests etc.)  
- Corrected toast messages. In earlier situation user get ```Facebook user not found``` toast message if user is not authenticated. I corrected that to ```Please Login```. And as the same way I corrected ```Logged In``` when user is authenticated

![login](https://cloud.githubusercontent.com/assets/11785398/24553196/f7d867f0-1646-11e7-9efc-66ee6b9e2d1d.png)
